### PR TITLE
Fix redirect when changing language from homepage

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -167,19 +167,19 @@
             <div style="display: inline-block">
               <ul id="lang-selector" style="padding: 0;list-style: none;">
                 <li>
-                  <a href="/language/en?origin=home" title="English">
+                  <a href="/language/en" title="English">
                     {{ _("English") }}
                   </a>
                 </li>
                 &nbsp;
                 <li>
-                  <a href="/language/es?origin=home" title="Spanish">
+                  <a href="/language/es" title="Spanish">
                     {{ _("Español") }}
                   </a>
                 </li>
                 &nbsp;
                 <li>
-                  <a href="/language/ca?origin=home" title="Catalan">
+                  <a href="/language/ca" title="Catalan">
                     {{ _("Català") }}
                   </a>
                 </li>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Changing language in homepage results in a 404 error due to the wrong parameters being sent in the request.

## Current behavior before PR

Changing language in homepage results in a 404 error

## Desired behavior after PR is merged

Changing language in homepage behaves as expected.

